### PR TITLE
Add GitHub Actions workflows to migrate away from Travis-CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,16 @@
+name: repo-checks
+
+on: [push]
+
+jobs:
+  main:
+    name: node_js
+    runs-on: [self-hosted, zendesk-stable]
+    steps:
+    - uses: zendesk/checkout@v2
+    - uses: zendesk/setup-node@v2.0.0
+      with:
+        node-version: '6'
+    - name: test
+      run: npm i && npm test
+

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   main:
     name: node_js
-    runs-on: [self-hosted, zendesk-stable]
+    runs-on: ubuntu-latest
     steps:
     - uses: zendesk/checkout@v2
     - uses: zendesk/setup-node@v2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-branches:
-  only: master
-
-language: node_js
-
-node_js:
-  - 6

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## Link-SF [![Build Status](https://travis-ci.org/zendesk/linksf.svg?branch=master)](https://travis-ci.org/zendesk/linksf) [![Code Climate](https://codeclimate.com/github/zendesk/linksf.png)](https://codeclimate.com/github/zendesk/linksf)
+## Link-SF 
+![repo-checks](https://github.com/zendesk/copenhelp/workflows/repo-checks/badge.svg)
+ [![Code Climate](https://codeclimate.com/github/zendesk/linksf.png)](https://codeclimate.com/github/zendesk/linksf)
 
 ### Open Referral Transition
 This version of linksf is currently undergoing a data model transition to be HSDS compliant.


### PR DESCRIPTION
https://zendesk.atlassian.net/browse/EP-4463

Please review and approve at your convenience. This change replaces Travis with GitHub actions.
Once approved, please also merge.

If you have questions, reach us on #github-actions-migration Slack channel.

